### PR TITLE
repo uris don't like relative paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,6 @@ bin/
 # Ignore Gradle GUI config
 gradle-app.setting
 
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
 
 # Avoid ignore Gradle wrappper properties
 !gradle-wrapper.properties
@@ -46,6 +44,8 @@ gradle-app.setting
 *.tar.gz
 *.rar
 
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
 
 # VSCode ignores
 .vscode/*

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 
 description = 'CICS Java JCICS samples'
 
+ext {
+    localRepo = file('local-repo')
+}
+
 allprojects {
     group = 'com.ibm.cicsdev'
     version = '1.0.1'
@@ -11,7 +15,7 @@ allprojects {
         
         // Local Maven repo for IRG generated file 
         maven {
-            url = uri("file:///../local-repo")
+            url = uri("file://${localRepo}")
             }  
         }
     }

--- a/cics-java-jcics-link-app/build.gradle
+++ b/cics-java-jcics-link-app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     //Compile using the IRG generated JAR from the local maven repo
     implementation ("com.ibm.cicsdev:cics-java-jcics-edupgm:1.0")   
     
-    }
+}
 
 
 


### PR DESCRIPTION
You could do it like this, but you can also reference dependencies in Gradle directly without using Maven coordinates, which I can show in a different PR